### PR TITLE
ci: automate GitHub releases

### DIFF
--- a/.github/scripts/assemble-release-body.py
+++ b/.github/scripts/assemble-release-body.py
@@ -1,0 +1,22 @@
+HEADER = """\
+<div align="center">
+  <img src="https://raw.githubusercontent.com/Agent-mag/.github/main/profile/agentmag-banner-github.png" alt="Agent Mag" width="600" />
+  <p><strong>Open registry of installable AI agent skills</strong> &middot; <a href="https://theagentmag.com/skills">theagentmag.com/skills</a></p>
+</div>
+
+---
+
+"""
+
+FOOTER = """
+
+---
+
+<sub>Release notes polished by Azure OpenAI &middot; <a href="https://theagentmag.com">theagentmag.com</a></sub>
+"""
+
+with open("/tmp/polished-changelog.md") as f:
+    changelog = f.read()
+
+with open("/tmp/release-body.md", "w") as f:
+    f.write(HEADER + changelog + FOOTER)

--- a/.github/scripts/polish-release-notes.py
+++ b/.github/scripts/polish-release-notes.py
@@ -1,0 +1,69 @@
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT", "")
+api_key = os.environ.get("AZURE_OPENAI_API_KEY", "")
+deployment = os.environ.get("AZURE_OPENAI_DEPLOYMENT", "")
+version_context = os.environ.get("VERSION_CONTEXT", "")
+
+with open("/tmp/raw-changelog.md") as f:
+    raw = f.read()
+
+if not endpoint or not api_key or not deployment:
+    print("Azure OpenAI not configured, using raw changelog", file=sys.stderr)
+    with open("/tmp/polished-changelog.md", "w") as f:
+        f.write(raw)
+    sys.exit(0)
+
+system_prompt = (
+    "You are a release notes writer for Agent Mag (theagentmag.com), "
+    "the publication and skill registry for AI agent builders. Rewrite the grouped commit "
+    "messages below into professional, polished release notes.\n\n"
+    "Rules:\n"
+    "- Keep the markdown section headers (### New Features, ### Bug Fixes, etc.)\n"
+    "- Rewrite each bullet into a clean, professional one-liner that describes what changed and why it matters\n"
+    "- Remove any commit hashes or technical jargon that end users would not care about\n"
+    "- Merge duplicate or closely related items into a single bullet\n"
+    "- Keep the stats line at the bottom (commits + contributors)\n"
+    "- Be concise but professional — this is for a public GitHub releases page\n"
+    "- Do not add sections that have no items\n"
+    "- Do not add any preamble or closing remarks — just the changelog content\n"
+    "- Output valid markdown only"
+)
+
+user_msg = version_context + "\n\nHere are the raw grouped commits:\n\n" + raw
+
+body = json.dumps({
+    "messages": [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_msg},
+    ],
+    "max_tokens": 4000,
+    "temperature": 0.3,
+}).encode("utf-8")
+
+url = (
+    f"{endpoint}/openai/deployments/{deployment}"
+    "/chat/completions?api-version=2024-12-01-preview"
+)
+req = urllib.request.Request(url, data=body, method="POST")
+req.add_header("Content-Type", "application/json")
+req.add_header("api-key", api_key)
+
+try:
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        data = json.loads(resp.read())
+        content = data["choices"][0]["message"]["content"]
+        if content.strip():
+            with open("/tmp/polished-changelog.md", "w") as f:
+                f.write(content)
+            print("GPT-4o polishing succeeded")
+        else:
+            raise ValueError("Empty response")
+except Exception as e:
+    print(f"GPT-4o failed ({e}), falling back to raw changelog", file=sys.stderr)
+    with open("/tmp/polished-changelog.md", "w") as f:
+        f.write(raw)

--- a/.github/workflows/release-cadence.yml
+++ b/.github/workflows/release-cadence.yml
@@ -1,0 +1,232 @@
+name: Auto Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      threshold:
+        description: "Merged PRs needed since the latest release"
+        required: false
+        default: "3"
+      release_type:
+        description: "Version bump to use when cutting a release"
+        required: false
+        default: "auto"
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+          - major
+      force_release:
+        description: "Create a release even if the PR threshold has not been met"
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: "Evaluate the cadence without creating a tag"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: auto-release-cadence-main
+  cancel-in-progress: false
+
+jobs:
+  maybe-release:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      THRESHOLD: ${{ inputs.threshold || '3' }}
+      REQUESTED_RELEASE_TYPE: ${{ inputs.release_type || 'auto' }}
+      FORCE_RELEASE: ${{ inputs.force_release || false }}
+      DRY_RUN: ${{ inputs.dry_run || false }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Evaluate release cadence
+        id: cadence
+        run: |
+          set -euo pipefail
+
+          git fetch --tags --force
+
+          if ! [[ "$THRESHOLD" =~ ^[0-9]+$ ]] || [ "$THRESHOLD" -lt 1 ]; then
+            echo "Threshold must be a positive integer. Received: $THRESHOLD" >&2
+            exit 1
+          fi
+
+          if latest=$(gh release view --json tagName,publishedAt --jq '.tagName + " " + .publishedAt' 2>/dev/null); then
+            LATEST_TAG="${latest%% *}"
+            SINCE="${latest#* }"
+          else
+            LATEST_TAG=""
+            SINCE="1970-01-01T00:00:00Z"
+          fi
+
+          echo "Latest release tag: ${LATEST_TAG:-none}"
+          echo "Counting merged PRs after: $SINCE"
+
+          gh api \
+            --paginate \
+            --slurp \
+            "repos/${GITHUB_REPOSITORY}/pulls?state=closed&base=main&sort=updated&direction=desc&per_page=100" \
+            > /tmp/pulls-pages.json
+
+          jq --arg since "$SINCE" '
+            [.[][] |
+              select(.merged_at != null and .merged_at > $since) |
+              {
+                number,
+                title,
+                merged_at,
+                url: .html_url,
+                author: .user.login,
+                labels: [.labels[].name]
+              } |
+              select((.author | test("^(github-actions\\[bot\\]|dependabot\\[bot\\])$")) | not) |
+              select((.labels | index("skip-release")) | not) |
+              select((.labels | index("skip-changelog")) | not)
+            ] | sort_by(.merged_at)
+          ' /tmp/pulls-pages.json > /tmp/release-prs.json
+
+          PR_COUNT=$(jq 'length' /tmp/release-prs.json)
+          echo "Included merged PRs: $PR_COUNT"
+
+          HAS_RELEASE_NOW=$(jq 'map(select(.labels | index("release:now"))) | length > 0' /tmp/release-prs.json)
+          HAS_MAJOR=$(jq 'map(select(.labels | index("release:major"))) | length > 0' /tmp/release-prs.json)
+          HAS_MINOR=$(jq 'map(select(.labels | index("release:minor"))) | length > 0' /tmp/release-prs.json)
+          HAS_PATCH=$(jq 'map(select(.labels | index("release:patch"))) | length > 0' /tmp/release-prs.json)
+
+          if [ "$REQUESTED_RELEASE_TYPE" != "auto" ]; then
+            RELEASE_TYPE="$REQUESTED_RELEASE_TYPE"
+          elif [ "$HAS_MAJOR" = "true" ]; then
+            RELEASE_TYPE="major"
+          elif [ "$HAS_MINOR" = "true" ]; then
+            RELEASE_TYPE="minor"
+          elif [ "$HAS_PATCH" = "true" ]; then
+            RELEASE_TYPE="patch"
+          else
+            RELEASE_TYPE="patch"
+          fi
+
+          SHOULD_RELEASE="false"
+          REASON="threshold-not-met"
+
+          if [ "$FORCE_RELEASE" = "true" ]; then
+            SHOULD_RELEASE="true"
+            REASON="manual-force"
+          elif [ "$HAS_RELEASE_NOW" = "true" ]; then
+            SHOULD_RELEASE="true"
+            REASON="release-now-label"
+          elif [ "$PR_COUNT" -ge "$THRESHOLD" ]; then
+            SHOULD_RELEASE="true"
+            REASON="threshold-met"
+          fi
+
+          if [ "$PR_COUNT" -eq 0 ] && [ "$FORCE_RELEASE" != "true" ]; then
+            SHOULD_RELEASE="false"
+            REASON="no-unreleased-prs"
+          fi
+
+          BASE_TAG="${LATEST_TAG:-v0.0.0}"
+          VERSION="${BASE_TAG#v}"
+          MAJOR="${VERSION%%.*}"
+          REST="${VERSION#*.}"
+          MINOR="${REST%%.*}"
+          PATCH="${REST#*.}"
+          PATCH="${PATCH%%[-+]*}"
+
+          if ! [[ "$MAJOR" =~ ^[0-9]+$ && "$MINOR" =~ ^[0-9]+$ && "$PATCH" =~ ^[0-9]+$ ]]; then
+            echo "Latest tag '$BASE_TAG' is not a simple semver tag." >&2
+            exit 1
+          fi
+
+          case "$RELEASE_TYPE" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+            *)
+              echo "Unsupported release type: $RELEASE_TYPE" >&2
+              exit 1
+              ;;
+          esac
+
+          NEXT_TAG="v${MAJOR}.${MINOR}.${PATCH}"
+
+          if git rev-parse -q --verify "refs/tags/$NEXT_TAG" >/dev/null; then
+            echo "Tag $NEXT_TAG already exists." >&2
+            exit 1
+          fi
+
+          {
+            echo "## Auto Release Cadence"
+            echo ""
+            echo "- Latest release: ${LATEST_TAG:-none}"
+            echo "- Included merged PRs: $PR_COUNT"
+            echo "- Threshold: $THRESHOLD"
+            echo "- Release type: $RELEASE_TYPE"
+            echo "- Next tag: $NEXT_TAG"
+            echo "- Decision: $SHOULD_RELEASE ($REASON)"
+            echo ""
+            echo "### Included PRs"
+            jq -r '.[] | "- #\(.number) \(.title) (\(.url))"' /tmp/release-prs.json
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          {
+            echo "should_release=$SHOULD_RELEASE"
+            echo "reason=$REASON"
+            echo "latest_tag=$LATEST_TAG"
+            echo "next_tag=$NEXT_TAG"
+            echo "release_type=$RELEASE_TYPE"
+            echo "pr_count=$PR_COUNT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Stop when release is not due
+        if: steps.cadence.outputs.should_release != 'true'
+        run: |
+          echo "Release not due: ${{ steps.cadence.outputs.reason }}"
+
+      - name: Create and push release tag
+        if: steps.cadence.outputs.should_release == 'true' && env.DRY_RUN != 'true'
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          TAG="${{ steps.cadence.outputs.next_tag }}"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+
+      - name: Dispatch release workflow
+        if: steps.cadence.outputs.should_release == 'true' && env.DRY_RUN != 'true'
+        run: |
+          gh workflow run release.yml --ref main -f tag="${{ steps.cadence.outputs.next_tag }}"
+
+      - name: Dry run result
+        if: steps.cadence.outputs.should_release == 'true' && env.DRY_RUN == 'true'
+        run: |
+          echo "Dry run: would create ${{ steps.cadence.outputs.next_tag }} and dispatch release.yml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,208 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to create release for (e.g. v1.0.0). Must already exist."
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "name=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Find previous tag
+        id: prev
+        run: |
+          CURRENT="${{ steps.tag.outputs.name }}"
+          PREV=$(git tag --sort=-version:refname | grep -E '^v[0-9]' | grep -v "^${CURRENT}$" | head -1)
+          echo "tag=${PREV:-}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate raw changelog from conventional commits
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          PREV="${{ steps.prev.outputs.tag }}"
+
+          if [ -n "$PREV" ]; then
+            RANGE="${PREV}..${TAG}"
+          else
+            RANGE="${TAG}"
+          fi
+
+          {
+            FEATS=$(git log "$RANGE" --pretty=format:"%s" --no-merges | grep -E "^feat(\(.*\))?:" || true)
+            if [ -n "$FEATS" ]; then
+              echo "### New Features"
+              echo "$FEATS" | while IFS= read -r line; do
+                scope=$(echo "$line" | sed -n 's/^feat(\([^)]*\)):.*/\1/p')
+                msg=$(echo "$line" | sed 's/^feat\([^:]*\): //')
+                if [ -n "$scope" ]; then
+                  echo "- **${scope}**: ${msg}"
+                else
+                  echo "- ${msg}"
+                fi
+              done
+              echo ""
+            fi
+
+            FIXES=$(git log "$RANGE" --pretty=format:"%s" --no-merges | grep -E "^fix(\(.*\))?:" || true)
+            if [ -n "$FIXES" ]; then
+              echo "### Bug Fixes"
+              echo "$FIXES" | while IFS= read -r line; do
+                scope=$(echo "$line" | sed -n 's/^fix(\([^)]*\)):.*/\1/p')
+                msg=$(echo "$line" | sed 's/^fix\([^:]*\): //')
+                if [ -n "$scope" ]; then
+                  echo "- **${scope}**: ${msg}"
+                else
+                  echo "- ${msg}"
+                fi
+              done
+              echo ""
+            fi
+
+            DOCS=$(git log "$RANGE" --pretty=format:"%s" --no-merges | grep -E "^docs(\(.*\))?:" || true)
+            if [ -n "$DOCS" ]; then
+              echo "### Documentation"
+              echo "$DOCS" | while IFS= read -r line; do
+                scope=$(echo "$line" | sed -n 's/^docs(\([^)]*\)):.*/\1/p')
+                msg=$(echo "$line" | sed 's/^docs\([^:]*\): //')
+                if [ -n "$scope" ]; then
+                  echo "- **${scope}**: ${msg}"
+                else
+                  echo "- ${msg}"
+                fi
+              done
+              echo ""
+            fi
+
+            STYLES=$(git log "$RANGE" --pretty=format:"%s" --no-merges | grep -E "^style(\(.*\))?:" || true)
+            if [ -n "$STYLES" ]; then
+              echo "### Styling"
+              echo "$STYLES" | while IFS= read -r line; do
+                scope=$(echo "$line" | sed -n 's/^style(\([^)]*\)):.*/\1/p')
+                msg=$(echo "$line" | sed 's/^style\([^:]*\): //')
+                if [ -n "$scope" ]; then
+                  echo "- **${scope}**: ${msg}"
+                else
+                  echo "- ${msg}"
+                fi
+              done
+              echo ""
+            fi
+
+            REFACTORS=$(git log "$RANGE" --pretty=format:"%s" --no-merges | grep -E "^refactor(\(.*\))?:" || true)
+            if [ -n "$REFACTORS" ]; then
+              echo "### Refactoring"
+              echo "$REFACTORS" | while IFS= read -r line; do
+                scope=$(echo "$line" | sed -n 's/^refactor(\([^)]*\)):.*/\1/p')
+                msg=$(echo "$line" | sed 's/^refactor\([^:]*\): //')
+                if [ -n "$scope" ]; then
+                  echo "- **${scope}**: ${msg}"
+                else
+                  echo "- ${msg}"
+                fi
+              done
+              echo ""
+            fi
+
+            INFRA=$(git log "$RANGE" --pretty=format:"%s" --no-merges | grep -E "^(chore|ci|build|perf)(\(.*\))?:" || true)
+            if [ -n "$INFRA" ]; then
+              echo "### Infrastructure & Maintenance"
+              echo "$INFRA" | while IFS= read -r line; do
+                scope=$(echo "$line" | sed -n 's/^[a-z]*(\([^)]*\)):.*/\1/p')
+                msg=$(echo "$line" | sed 's/^[a-z]*\([^:]*\): //')
+                if [ -n "$scope" ]; then
+                  echo "- **${scope}**: ${msg}"
+                else
+                  echo "- ${msg}"
+                fi
+              done
+              echo ""
+            fi
+
+            OTHER=$(git log "$RANGE" --pretty=format:"%s" --no-merges | grep -vE "^(feat|fix|docs|style|refactor|chore|ci|build|perf|test)(\(.*\))?:" || true)
+            if [ -n "$OTHER" ]; then
+              echo "### Other Changes"
+              echo "$OTHER" | while IFS= read -r line; do
+                echo "- ${line}"
+              done
+              echo ""
+            fi
+
+            COMMIT_COUNT=$(git rev-list --count --no-merges "$RANGE" 2>/dev/null || echo "0")
+            CONTRIBUTORS=$(git log "$RANGE" --pretty=format:"%an" 2>/dev/null | sort -u | wc -l | tr -d ' ')
+            printf "\n---\n**%s commits** from **%s contributor(s)**\n" "$COMMIT_COUNT" "$CONTRIBUTORS"
+          } > /tmp/raw-changelog.md
+
+          echo "Generated raw changelog:"
+          cat /tmp/raw-changelog.md
+
+      - name: Polish with GPT-4o
+        env:
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          PREV="${{ steps.prev.outputs.tag }}"
+
+          if [ -n "$PREV" ]; then
+            export VERSION_CONTEXT="This is release ${TAG}, covering changes since ${PREV}."
+          else
+            export VERSION_CONTEXT="This is the initial release ${TAG}, covering the full project history."
+          fi
+
+          python3 .github/scripts/polish-release-notes.py
+
+      - name: Assemble branded release body
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+          PREV="${{ steps.prev.outputs.tag }}"
+
+          if [ -z "$PREV" ]; then
+            TITLE="${TAG} — Initial Release"
+          else
+            TITLE="${TAG}"
+          fi
+          echo "RELEASE_TITLE=${TITLE}" >> "$GITHUB_ENV"
+
+          python3 .github/scripts/assemble-release-body.py
+
+          echo "Assembled release body:"
+          cat /tmp/release-body.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.name }}"
+
+          PRERELEASE=""
+          if echo "$TAG" | grep -qE "(alpha|beta|rc|pre)"; then
+            PRERELEASE="--prerelease"
+          fi
+
+          gh release create "$TAG" \
+            --title "${RELEASE_TITLE}" \
+            --notes-file /tmp/release-body.md \
+            $PRERELEASE


### PR DESCRIPTION
## Summary
- add tag-driven GitHub release publishing with grouped changelog generation
- add GPT-4o/Azure OpenAI release-note polishing with raw changelog fallback
- add auto-release cadence that cuts a tag after 3 included merged PRs by default

## Controls
- skips PRs labeled `skip-release` or `skip-changelog`
- supports `release:major`, `release:minor`, `release:patch`, and `release:now` labels
- includes manual dry-run and force-release controls

## Validation
- parsed both workflow YAML files locally
- smoke-tested latest-release PR counting against `v0.1.0`; found 0 unreleased PRs as expected